### PR TITLE
updated get_global_pvalue to return selections

### DIFF
--- a/Code/stratMartExample.ipynb
+++ b/Code/stratMartExample.ipynb
@@ -41,72 +41,101 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "722d12cf",
+   "id": "69c23f44",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "IndexError",
+     "evalue": "index 179 is out of bounds for axis 0 with size 179",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [3]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m p_value, stratum_selections, null_selections \u001b[38;5;241m=\u001b[39m \u001b[43mget_global_pvalue\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m    \u001b[49m\u001b[43mstrata\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43mstratum_1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstratum_2\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m    \u001b[49m\u001b[43mu\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mu\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m    \u001b[49m\u001b[43mv\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mv\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m    \u001b[49m\u001b[43mrule\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mmultinomial_selector\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Dropbox/RLAs/alpha/Code/utils.py:287\u001b[0m, in \u001b[0;36mget_global_pvalue\u001b[0;34m(strata, u, v, rule)\u001b[0m\n\u001b[1;32m    285\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m np\u001b[38;5;241m.\u001b[39marange(\u001b[38;5;28msum\u001b[39m(N)):\n\u001b[1;32m    286\u001b[0m     minimized_martingale[i] \u001b[38;5;241m=\u001b[39m intersection_marts[i,null_index[i]]\n\u001b[0;32m--> 287\u001b[0m     stratum_selections[i] \u001b[38;5;241m=\u001b[39m \u001b[43mstrata_matrix\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m,\u001b[49m\u001b[43mnull_index\u001b[49m\u001b[43m[\u001b[49m\u001b[43mi\u001b[49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m    288\u001b[0m p_value \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m \u001b[38;5;241m/\u001b[39m np\u001b[38;5;241m.\u001b[39mmaximum(\u001b[38;5;241m1\u001b[39m, minimized_martingale)\n\u001b[1;32m    289\u001b[0m null_selections \u001b[38;5;241m=\u001b[39m theta_1_grid[null_index]\n",
+      "\u001b[0;31mIndexError\u001b[0m: index 179 is out of bounds for axis 0 with size 179"
+     ]
+    }
+   ],
+   "source": [
+    "p_value, stratum_selections, null_selections = get_global_pvalue(\n",
+    "    strata = [stratum_1, stratum_2], \n",
+    "    u = u, \n",
+    "    v = v, \n",
+    "    rule = multinomial_selector)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "988cbe58",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 8.20351745e-01, 6.08537263e-01, 4.83073919e-01,\n",
-       "       4.83073919e-01, 3.82440112e-01, 3.01931655e-01, 2.37695047e-01,\n",
-       "       1.96095207e-01, 1.84056938e-01, 1.72624764e-01, 1.30833950e-01,\n",
-       "       1.06157373e-01, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 1.00000000e+00, 1.00000000e+00, 1.00000000e+00,\n",
-       "       1.00000000e+00, 8.56156313e-01, 4.32408005e-01, 1.96982957e-01,\n",
-       "       7.84386363e-02, 1.46160136e-01, 5.13130460e-02, 9.68777579e-02,\n",
-       "       2.78285254e-02, 5.09133070e-03, 1.01632233e-02, 5.97910677e-04,\n",
-       "       1.89414826e-06, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00,\n",
-       "       0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00,\n",
-       "       0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00])"
+       "(179, 180)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "get_global_pvalue(strata = [stratum_1, stratum_2], u = u, v = v, rule = multinomial_selector)"
+    "p_value.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "47df2558",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "only integer scalar arrays can be converted to a scalar index",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [15]\u001b[0m, in \u001b[0;36m<cell line: 22>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     16\u001b[0m     strata_matrix[:,i], intersection_marts[:,i] \u001b[38;5;241m=\u001b[39m stratum_selector(\n\u001b[1;32m     17\u001b[0m         marts \u001b[38;5;241m=\u001b[39m [mart_1, mart_2],\n\u001b[1;32m     18\u001b[0m         mu \u001b[38;5;241m=\u001b[39m [mu_1, mu_2],\n\u001b[1;32m     19\u001b[0m         u \u001b[38;5;241m=\u001b[39m u,\n\u001b[1;32m     20\u001b[0m         rule \u001b[38;5;241m=\u001b[39m rule)\n\u001b[1;32m     21\u001b[0m null_index \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39margmin(intersection_marts, axis \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m)\n\u001b[0;32m---> 22\u001b[0m minimized_martingale \u001b[38;5;241m=\u001b[39m intersection_marts[\u001b[38;5;28;43mrange\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mN\u001b[49m\u001b[43m)\u001b[49m,null_index]\n\u001b[1;32m     23\u001b[0m p_value \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m \u001b[38;5;241m/\u001b[39m np\u001b[38;5;241m.\u001b[39mmaximum(\u001b[38;5;241m1\u001b[39m, minimized_martingale)\n\u001b[1;32m     24\u001b[0m stratum_selections \u001b[38;5;241m=\u001b[39m strata_matrix[\u001b[38;5;241m1\u001b[39m:N,null_index]\n",
+      "\u001b[0;31mTypeError\u001b[0m: only integer scalar arrays can be converted to a scalar index"
+     ]
+    }
+   ],
+   "source": [
+    "strata = [stratum_1, stratum_2]\n",
+    "rule = multinomial_selector\n",
+    "\n",
+    "shuffled_1 = np.random.permutation(strata[0])\n",
+    "shuffled_2 = np.random.permutation(strata[1])\n",
+    "N = np.concatenate((np.array([len(shuffled_1)]), np.array([len(shuffled_2)])))\n",
+    "w = N/sum(N)\n",
+    "epsilon = 1 / (2*np.max(N))\n",
+    "theta_1_grid = np.arange(epsilon, u[0] - epsilon, epsilon) #sequence from epsilon to u[0] - epsilon\n",
+    "theta_2_grid = (1/2 - w[0] * theta_1_grid) / w[1]\n",
+    "strata_matrix = np.zeros((len(shuffled_1) + len(shuffled_2) - 1, len(theta_1_grid)))\n",
+    "intersection_marts = np.zeros((len(shuffled_1) + len(shuffled_2), len(theta_1_grid)))\n",
+    "for i in range(len(theta_1_grid)):\n",
+    "    mart_1, mu_1 = alpha_mart(x = shuffled_1, N = N[0], mu = theta_1_grid[i], eta = 1/(2-v[0]), f = .01, u = u[0])\n",
+    "    mart_2, mu_2 = alpha_mart(x = shuffled_2, N = N[1], mu = theta_2_grid[i], eta = 1/(2-v[1]), f = .01, u = u[1])\n",
+    "    strata_matrix[:,i], intersection_marts[:,i] = stratum_selector(\n",
+    "        marts = [mart_1, mart_2],\n",
+    "        mu = [mu_1, mu_2],\n",
+    "        u = u,\n",
+    "        rule = rule)\n",
+    "null_index = np.argmin(intersection_marts, axis = 1)\n",
+    "minimized_martingale = intersection_marts[range(N),null_index]\n",
+    "p_value = 1 / np.maximum(1, minimized_martingale)\n",
+    "stratum_selections = strata_matrix[1:N,null_index]\n",
+    "null_selections = theta_1_grid[null_index]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47df2558",
+   "id": "175f6fb5",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Now returns the strata selections (for the minimum martingale) and the null selections. Note: array indexing for these selections should probably be updated so it isn't done with a for loop (seems unnecessary). 