### PR TITLE
fix bug in alpha_mart comparison simulation

### DIFF
--- a/Code/alpha.ipynb
+++ b/Code/alpha.ipynb
@@ -910,7 +910,7 @@
     "    m = (N*mu-S)/(N-j+1) if np.isfinite(N) else mu   # mean of population after (j-1)st draw, if null is true \n",
     "    etaj = estim(x, N, mu, eta, u) \n",
     "    with np.errstate(divide='ignore',invalid='ignore'):\n",
-    "        terms = np.cumprod((x*etaj/m + (1-x)*(u-etaj)/(u-m))/u)\n",
+    "        terms = np.cumprod((x*etaj/m + (u-x)*(u-etaj)/(u-m))/u)\n",
     "    terms[m<0] = np.inf\n",
     "    return terms\n",
     "\n",


### PR DESCRIPTION
Minor bug in one of the alpha_mart functions.

After fixing, output from last cell in alpha.ipybn went from

```
 \eta & d=10, d=100 & d=1,000 & d=10,000 & d=100,000\\ \hline
 0.900 & 9,892  & 9,885  & 9,752  & 598  & 558  \\
 1.000 & 9,892  & 9,882  & 566  & 349  & 338  \\
 1.009 & 9,892  & 9,882  & 519  & 336  & 326  \\
 2.000 & 9,889  & 9,846  & 325  & 325  & 325  \\
 2.018 & 9,889  & 9,846  & 325  & 325  & 325  \\
```

to

```
 \eta & d=10, d=100 & d=1,000 & d=10,000 & d=100,000\\ \hline
 0.900 & 7,225  & 3,000  & 506  & 420  & 413  \\
 1.000 & 7,161  & 1,899  & 391  & 337  & 332  \\
 1.009 & 7,155  & 1,824  & 383  & 331  & 326  \\
 2.000 & 5,904  & 357  & 325  & 325  & 325  \\
 2.018 & 5,870  & 355  & 325  & 325  & 325  \\
``` 